### PR TITLE
Add typescript interface delimiter rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,6 +77,7 @@ module.exports = {
         'no-empty-function': 'off',
         '@typescript-eslint/no-empty-function': 'off',
         '@typescript-eslint/no-var-requires': 'off',
+        '@typescript-eslint/member-delimiter-style': ['error'],
       },
     },
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-hayanmind",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
* Add typescript interface delimiter rule
* https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/member-delimiter-style.md#require-a-specific-member-delimiter-style-for-interfaces-and-type-literals-member-delimiter-style