### PR TITLE
Version 1.0.3

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ module.exports = {
         'react/require-default-props': ['off'],
         'react/jsx-props-no-spreading': 'off',
         'no-use-before-define': 'off', // https://stackoverflow.com/a/64024916
-        '@typescript-eslint/no-use-before-define': ['error'],
+        '@typescript-eslint/no-use-before-define': ['nofunc'],
         'no-empty-function': 'off',
         '@typescript-eslint/no-empty-function': 'off',
         '@typescript-eslint/no-var-requires': 'off',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-hayanmind",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
According to this [rule](https://github.com/ryanmcdermott/clean-code-javascript#function-callers-and-callees-should-be-close) of clean code, it's better to disable `no-use-before-define` rule for function.
Eslint rule [ref](https://eslint.org/docs/latest/rules/no-use-before-define)