### PR TITLE
Bump typescript eslint version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-hayanmind",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {
@@ -10,8 +10,8 @@
     "@babel/core": "^7.14.8",
     "@babel/eslint-parser": "^7.14.7",
     "@babel/preset-react": "^7.14.5",
-    "@typescript-eslint/eslint-plugin": "^4.28.5",
-    "@typescript-eslint/parser": "^4.28.5",
+    "@typescript-eslint/eslint-plugin": "^5.42.1",
+    "@typescript-eslint/parser": "^5.42.1",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-airbnb-typescript": "^12.3.1",
     "eslint-plugin-import": "^2.23.4",


### PR DESCRIPTION
<img width="1275" alt="스크린샷 2022-11-08 오후 4 23 17" src="https://user-images.githubusercontent.com/46129472/200500712-c49d8208-369b-422f-a82d-1f0c2498ad9c.png">

After upgrading typescript version, I get warning message upper.

<img width="855" alt="스크린샷 2022-11-08 오후 4 23 27" src="https://user-images.githubusercontent.com/46129472/200500754-d303338d-b256-4ac4-a4b5-94730bdb570a.png">

I checked latest version support previous typescript version!
[Link](https://github.com/typescript-eslint/typescript-eslint#readme)